### PR TITLE
Filter nav bar by whitelist instead of blacklist.

### DIFF
--- a/_includes/pages-list.html
+++ b/_includes/pages-list.html
@@ -7,7 +7,7 @@
 	<a class="page-link" href="{{site.blog_url}}">Blog</a>
     </li>
         {% for page in site.pages %}
-          {% if page.title and page.type != 'hidden' %}
+          {% if page.title and page.type == 'inNavBar' %}
             <li>
               <a class="page-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
             </li>

--- a/about.html
+++ b/about.html
@@ -2,6 +2,7 @@
 title: What We Do
 permalink: "/about/"
 layout: page
+type: inNavBar
 ---
 
 <h1 class="t-section-headline">What we do</h1>

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -2,7 +2,7 @@
 title: Code of Conduct
 permalink: "/code-of-conduct/"
 layout: page
-type: none
+type: inNavBar
 ---
 
 {: .t-section-headline }

--- a/projects.html
+++ b/projects.html
@@ -2,6 +2,7 @@
 title: Projects
 permalink: "/projects/"
 layout: page
+type: inNavBar
 ---
 
 <h1 class="t-section-headline">Projects</h1>


### PR DESCRIPTION
This fixes the reveal.js .md files unintentionally showing up in the nav bar