### PR TITLE
Embed video for projects; addresses #32

### DIFF
--- a/_data/projects/active.yml
+++ b/_data/projects/active.yml
@@ -37,17 +37,17 @@
   news: >
     Code and UI/UX for the invisible women of Delhi
     React and React Native 
-    https://www.dropbox.com/s/bqmc9ivmt50hxrz/JASKEERAT_HEADLINE_2.mp4?dl=0
+  media: <iframe width="560" height="315" src="https://www.youtube.com/embed/PPGhJ9biv_I?start=9" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 -
-  name: Community Engagement - DACA Litigation
-  url: goo.gl/2Y51UC
-  news: >
-    On pause while AGO is on winter recess.
+#   name: Community Engagement - DACA Litigation
+#   url: goo.gl/2Y51UC
+#   news: >
+#     On pause while AGO is on winter recess.
 
-    Amassing Dreamers' narratives to power MA Attorney General's Office's litigation against DACA program recission.
+#     Amassing Dreamers' narratives to power MA Attorney General's Office's litigation against DACA program recission.
 
-    Skillsets: survey creation, community outreach, and social design.
--
+#     Skillsets: survey creation, community outreach, and social design.
+# -
   name: MuckRock
   url: https://www.muckrock.com/
   news: >

--- a/_data/projects/active.yml
+++ b/_data/projects/active.yml
@@ -37,7 +37,7 @@
   news: >
     Code and UI/UX for the invisible women of Delhi
     React and React Native 
-  media: <iframe width="560" height="315" src="https://www.youtube.com/embed/PPGhJ9biv_I?start=9" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+  media: <iframe width="1120" height="630" src="https://www.youtube.com/embed/PPGhJ9biv_I?start=9" frameborder="0" data-autoplay allowfullscreen></iframe>
 -
 #   name: Community Engagement - DACA Litigation
 #   url: goo.gl/2Y51UC

--- a/hacknight.html
+++ b/hacknight.html
@@ -7,7 +7,6 @@ type: hidden
 
 <section>
   Welcome to Code for Boston!
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/PPGhJ9biv_I?start=9" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </section>
 
 <section data-markdown>
@@ -82,6 +81,15 @@ type: hidden
         {{proj.news | markdownify}}
       </textarea>
     </section>
+
+    {% if proj.media %}
+      <section data-markdown>
+        <textarea data-template>
+          {{proj.media}}
+        </textarea>
+      </section>
+    {% endif %}
+
   {% endfor %}
 </section>
 

--- a/hacknight.html
+++ b/hacknight.html
@@ -5,7 +5,10 @@ layout: hacknight
 type: hidden
 ---
 
-<section>Welcome to Code for Boston!</section>
+<section>
+  Welcome to Code for Boston!
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/PPGhJ9biv_I?start=9" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+</section>
 
 <section data-markdown>
   <textarea data-template>


### PR DESCRIPTION
As per #32: Embeds a video pitch in hacknight.html, sourced through a media attribute in projects' active.yml.

Caveats:
1. iframe dimensions are hardcoded because could not successfully implement reveal.js' stretch class.
2. Video pitch for i-docs team is WIP; video that is currently linked, though heartwarming, is filler.