### PR TITLE
Fix donation url link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,7 +21,7 @@
             {% endif %} {% endfor %}
             <li>
               <a
-                href="{https://opencollective.com/code-for-boston/donate?interval=oneTime&amount=20&name=&legalName=&email="
+                href="https://opencollective.com/code-for-boston/donate?interval=oneTime&amount=20&name=&legalName=&email="
                 class="btn-primary btn--small"
               >
                 Donate


### PR DESCRIPTION
Fixes the donation url which has an extra { at the beginning of it

Before:
![CleanShot 2026-02-18 at 22 05 24](https://github.com/user-attachments/assets/15953b01-a821-440b-824c-32d6f99cc1b0)


After:
![CleanShot 2026-02-18 at 22 05 48](https://github.com/user-attachments/assets/04841ac3-31ce-4d38-a27e-7a7045547856)
